### PR TITLE
Web push notifications - use subscribe() with vapid key when sub object is null

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -77,22 +77,6 @@ function App() {
               notificationApi.askForWebPushPermission();
             }
             if (perm === "granted") {
-              // worker.pushManager.getSubscription().then((sub) => {
-              //   console.log(sub);
-              //   if (sub) {
-              //     getAndSendSub(worker);
-              //   } else {
-              //     getVapKey().then((key) => {
-              //       console.log("Vapkey = ", key);
-              //       worker.pushManager.subscribe({
-              //         userVisibleOnly: true,
-              //         applicationServerKey: key,
-              //       }).then((freshSub) => {
-              //         getAndSendSub(worker);
-              //       });
-              //     });
-              //   }
-              // });
               getAndSendSub(worker);
             }
           });
@@ -111,11 +95,9 @@ function App() {
             })
             .then((freshSub) => {
               sub = freshSub;
-              console.log("Fresh sub: ", sub);
             });
         });
       }
-      console.log("sub: ", sub);
       const subAsJson = sub.toJSON();
       sendWebPushTokens(subAsJson);
     });

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Header from "./components/Header/Header";
 import SignupPage from "./pages/SignupPage/SignupPage";
 import {
   getCurrentUserEndpoint,
+  getVapKeyEndpoint,
   postWebPushEndpoint,
 } from "./utils/networkUtils";
 import axios from "axios";
@@ -76,9 +77,23 @@ function App() {
               notificationApi.askForWebPushPermission();
             }
             if (perm === "granted") {
-              worker.pushManager.getSubscription().then((sub) => {
-                getAndSendSub(worker);
-              });
+              // worker.pushManager.getSubscription().then((sub) => {
+              //   console.log(sub);
+              //   if (sub) {
+              //     getAndSendSub(worker);
+              //   } else {
+              //     getVapKey().then((key) => {
+              //       console.log("Vapkey = ", key);
+              //       worker.pushManager.subscribe({
+              //         userVisibleOnly: true,
+              //         applicationServerKey: key,
+              //       }).then((freshSub) => {
+              //         getAndSendSub(worker);
+              //       });
+              //     });
+              //   }
+              // });
+              getAndSendSub(worker);
             }
           });
       });
@@ -87,9 +102,35 @@ function App() {
 
   function getAndSendSub(worker) {
     worker.pushManager.getSubscription().then((sub) => {
+      if (!sub) {
+        getVapKey().then((key) => {
+          worker.pushManager
+            .subscribe({
+              userVisibleOnly: true,
+              applicationServerKey: key,
+            })
+            .then((freshSub) => {
+              sub = freshSub;
+            });
+        });
+      }
       const subAsJson = sub.toJSON();
       sendWebPushTokens(subAsJson);
     });
+  }
+
+  async function getVapKey() {
+    try {
+      const token = localStorage.getItem("token");
+      const vKey = await axios.get(getVapKeyEndpoint(), {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      return vKey.data.vkey;
+    } catch (error) {
+      console.log(error);
+    }
   }
 
   const handleLogout = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -111,9 +111,11 @@ function App() {
             })
             .then((freshSub) => {
               sub = freshSub;
+              console.log("Fresh sub: ", sub);
             });
         });
       }
+      console.log("sub: ", sub);
       const subAsJson = sub.toJSON();
       sendWebPushTokens(subAsJson);
     });

--- a/src/utils/networkUtils.js
+++ b/src/utils/networkUtils.js
@@ -26,3 +26,5 @@ export const postWebPushEndpoint = () => `${BASE}/user/webpush`;
 export const deleteUserEndpoint = () => `${BASE}/user/delete`;
 
 export const putEditUserEndpoint = () => `${BASE}/user/edit`;
+
+export const getVapKeyEndpoint = () => `${BASE}/user/vap`;


### PR DESCRIPTION
- If the getSubscription() method for web push subscriptions returns a null subscription object, use subscribe() instead.
- This method requires a vapid key, so get that from the server.
- Also move the webpush subscription logic into a separate function.