### PR TITLE
Fix 'Refill By' showing epoch date when refill date is null

### DIFF
--- a/src/components/MedicineCard/MedicineCard.js
+++ b/src/components/MedicineCard/MedicineCard.js
@@ -17,10 +17,12 @@ const MedicineCard = ({ medication }) => {
 
   let interval;
   let cronDescription;
-  const refillBy = new Date(medication.refill_reminder_date).toLocaleString(
-    "en-us",
-    { dateStyle: "medium" }
-  );
+
+  const refillBy = medication.refill_reminder_date
+    ? new Date(medication.refill_reminder_date).toLocaleString("en-us", {
+        dateStyle: "medium",
+      })
+    : "No Date Set";
 
   return (
     <Card className="medicine-card border-success bg-light mb-3">


### PR DESCRIPTION
- Check if refill reminder date is null and if it is, display "No Date Set" instead of epoch date.